### PR TITLE
some yaml linting and additional stanza for AMD supermicro box

### DIFF
--- a/bios_settings.yml
+++ b/bios_settings.yml
@@ -147,7 +147,6 @@ HPE:
       PerformanceDeterminism: PerformanceDeterministic
       PowerRegulator: StaticHighPerf
       ProcSMT: Disabled
-      ProcAmdIoVt: Disabled
       BootMode: Uefi
       SecureBootStatus: Disabled
     '*':
@@ -166,10 +165,8 @@ HPE:
       PerformanceDeterminism: PerformanceDeterministic
       PowerRegulator: StaticHighPerf
       ProcSMT: Disabled
-      ProcAmdIoVt: Disabled
       BootMode: Uefi
       SecureBootStatus: Disabled
-
   Intel:
     '*':
       IntelProcVtd: Disabled
@@ -178,6 +175,18 @@ HPE:
       ProcHyperthreading: Enabled
 Supermicro:
   AMD:
+    ASG-1115S-NE316R:
+      WorkloadProfile: I/O
+      CorePerformanceBoost: Auto
+      SecureBootEnable: false
+      SMTControl: Disabled
+      SR_IOVSupport: Enabled
+      IOMMU: Enabled
+      GlobalC_stateControl: Disabled
+      DFCstates: Disabled
+      NUMANodesPerSocket: Auto
+      ACPISRATL3CacheAsNUMADomain: Disabled
+      DeterminismControl: Manual
     AS -1115CS-TNR:
       ACPISRATL3CacheAsNUMADomain_0099: Disabled
       DFCstates_7103: Disabled


### PR DESCRIPTION
additive changes: new stanza for SuperMicro AMD 

subtractive changes: 
- duplicative AMD keys that were setting ProcAmdIoVt to enabled and disabled in the same stanza
- a whitespace that was sitting in front of a colon